### PR TITLE
Fixes failing deposits in certain situations on Metamask Mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/hyphen",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Hyphen SDK to enable instant and seamless cross-chain deposits & withdrawals",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,7 +475,7 @@ class Hyphen {
             if(isNativeAddress(request.tokenAddress)) {
                 const { data } = await lpManager.populateTransaction.depositNative(request.receiver, request.toChainId);
                 txData = data;
-                value = ethers.BigNumber.from(request.amount).toHexString();
+                value = ethers.utils.hexValue(ethers.BigNumber.from(request.amount));
             } else {
                 const { data } = await lpManager.populateTransaction.depositErc20(request.tokenAddress, request.receiver,
                     request.amount, request.toChainId);


### PR DESCRIPTION
The issue:
`toHexString()` will add a leading 0 to odd length hex numbers. Metamask mobile does not handle this well and deposit fails with `invalid argument 0: json: cannot unmarshal hex number with leading zero digits into Go struct field TransactionArgs.value of type *hexutil.Big`

How to reproduce:
1. Open https://test-hyphen.biconomy.io on Metamask Mobile
2. Do a cross-chain transfer of 0.288 ETH 
3. Deposit will fail

Fix: 
Replace `toHexString()` with `ethers.utils.hexValue`, which does not add leading 0